### PR TITLE
Fix: Make session button more visible

### DIFF
--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -12,7 +12,7 @@ function MainMenu({ user }: MainMenuProps) {
       description: 'Begin een nieuwe oefensessie',
       icon: '📚',
       link: '/session',
-      color: 'bg-french-blue hover:bg-blue-700',
+      color: 'bg-blue-400 hover:bg-blue-600',
     },
     {
       title: 'Voortgang',
@@ -51,12 +51,12 @@ function MainMenu({ user }: MainMenuProps) {
           </div>
         </header>
 
-        <div className="grid md:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           {menuItems.map((item) => (
             <Link
               key={item.link}
               to={item.link}
-              className={`${item.color} text-white rounded-2xl p-8 text-center transform transition-all duration-200 hover:scale-105 hover:shadow-xl`}
+              className={`${item.color} text-white rounded-2xl p-8 text-center transform transition-all duration-200 hover:scale-105 hover:shadow-xl block`}
             >
               <div className="text-6xl mb-4">{item.icon}</div>
               <h2 className="text-2xl font-bold mb-2">{item.title}</h2>


### PR DESCRIPTION
## Summary
- Changed session button color from dark blue to light blue (bg-blue-400) for better visibility
- Added darker hover state (bg-blue-600) for improved user interaction

## Problem
The "Start Sessie" button was not clearly visible in the main menu, as shown in the user's screenshot.

## Solution
- Updated the session button to use a lighter blue color that stands out better
- Maintained consistency with hover effects for better UX
- Ensured responsive grid layout works properly

## Test plan
- [x] Verify session button is now clearly visible with light blue color
- [x] Confirm hover effect changes to darker blue
- [x] Check that all three menu buttons display correctly in grid layout

🤖 Generated with [Claude Code](https://claude.ai/code)